### PR TITLE
sort keywords

### DIFF
--- a/denote-db.el
+++ b/denote-db.el
@@ -357,8 +357,8 @@ you use that option."
                 (denote-retrieve-filename-title file)
                 (file-name-base file)))
            (keywords-list
-            (or (denote-retrieve-front-matter-keywords-value file type)
-                (denote-extract-keywords-from-path file)))
+            (sort (or (denote-retrieve-front-matter-keywords-value file type)
+                      (denote-extract-keywords-from-path file))))
            (signature
             (or (denote-retrieve-front-matter-signature-value file type)
                 (denote-retrieve-filename-signature file)))


### PR DESCRIPTION
With vetico, orderless and the following function:

     (use-package denote-db
       :ensure nil
       :bind* ("C-0" . denote-db-keyword-dwim)
       ;; disable denote-db-update-modedenote-db-update-mode before bulk Edit Dired buffer with Wdired
       :hook (after-init . denote-db-update-modedenote-db-update-mode)
       :config
       (setq denote-prompts '(keywords))
       (setq denote-infer-keywords nil)
       (setq denote-id-format "%m%dT%H")
       (setq denote-id-regexp "\\([0-9]\\{4\\}\\)\\(T[0-9]\\{6\\}\\)")
       (setq denote-org-front-matter "#+filetags: %s")
     
       (defun denote-db-keyword-dwim ()
         (interactive)
         (let* ((data (mapcar (lambda (item)
                                (cons (string-join (car item) ":") (cadr item)))
                              (denote-db-query :select '(keywords file))))
                ;; tags are separated with space
                (tags (completing-read "Select note: " data))
                (time (current-time))
                (files (let (result)
                         (dolist (item data)
                           (when (equal tags (car item))
                             (add-to-list 'result (cdr item))))))
                (file-num (length files)))
           (cond ((equal file-num 0)
                  (denote nil (list (format-time-string "%M%S" time)) denote-file-type
                          (expand-file-name (format-time-string "%Y" time) denote-directory))
                  (insert (format ":%s:" (string-join (split-string tags) ":"))))
                 ((equal file-num 1) (find-file (car files)))
                 (t (find-file (completing-read "Select file: " files)))))))

I almost successfully build a tags/keywords centric workflow discussed in
https://github.com/lmq-10/denote-db/issues/1